### PR TITLE
feat: externalize styles and introduce design tokens

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,0 +1,98 @@
+:root {
+  --color-background: #1a1a1a;
+  --color-section-dark: #262626;
+  --color-orange: #ff4f00;
+  --color-light: #eaeaea;
+  --color-text-light: #ffffff;
+  --color-text-dark: #111111;
+
+  --font-family-base: 'Helvetica Neue', sans-serif;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 3rem;
+
+  --spacing-xs: 0.5rem;
+  --spacing-sm: 0.75rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 2rem;
+  --spacing-xl: 3rem;
+  --spacing-xxl: 4rem;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  background-color: var(--color-background);
+  color: var(--color-text-light);
+}
+
+header {
+  padding: var(--spacing-xl);
+  text-align: center;
+  background: url('https://source.unsplash.com/featured/?desk,workspace') no-repeat center;
+  background-size: cover;
+}
+
+h1 {
+  font-size: var(--font-size-xl);
+  margin-bottom: var(--spacing-sm);
+}
+
+p.lead {
+  font-size: var(--font-size-lg);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.section {
+  padding: var(--spacing-xxl) var(--spacing-lg);
+}
+
+.section.dark {
+  background-color: var(--color-section-dark);
+}
+
+.section.orange {
+  background-color: var(--color-orange);
+  color: var(--color-text-light);
+}
+
+.button {
+  display: inline-block;
+  background-color: var(--color-orange);
+  color: var(--color-text-light);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: 999px;
+  text-decoration: none;
+  margin-top: var(--spacing-md);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-lg);
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+footer {
+  background: var(--color-light);
+  color: var(--color-text-dark);
+  padding: var(--spacing-lg);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+input, textarea {
+  width: 100%;
+  padding: var(--spacing-sm);
+  margin: var(--spacing-xs) 0;
+  border-radius: 8px;
+  border: none;
+}
+
+form {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/index.html
+++ b/index.html
@@ -4,74 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AstraNova | Health & Technology Innovation</title>
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Helvetica Neue', sans-serif;
-      background-color: #1a1a1a;
-      color: white;
-    }
-    header {
-      padding: 3rem;
-      text-align: center;
-      background: url('https://source.unsplash.com/featured/?desk,workspace') no-repeat center;
-      background-size: cover;
-    }
-    h1 {
-      font-size: 3rem;
-      margin-bottom: 0.5rem;
-    }
-    p.lead {
-      font-size: 1.25rem;
-      max-width: 600px;
-      margin: 0 auto;
-    }
-    .section {
-      padding: 4rem 2rem;
-    }
-    .section.dark {
-      background-color: #262626;
-    }
-    .section.orange {
-      background-color: #ff4f00;
-      color: white;
-    }
-    .button {
-      display: inline-block;
-      background-color: #ff4f00;
-      color: white;
-      padding: 0.75rem 2rem;
-      border-radius: 999px;
-      text-decoration: none;
-      margin-top: 1rem;
-    }
-    .grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 2rem;
-      max-width: 1000px;
-      margin: 0 auto;
-    }
-    footer {
-      background: #eaeaea;
-      color: #111;
-      padding: 2rem;
-      display: flex;
-      justify-content: space-between;
-      flex-wrap: wrap;
-    }
-    input, textarea {
-      width: 100%;
-      padding: 0.75rem;
-      margin: 0.5rem 0;
-      border-radius: 8px;
-      border: none;
-    }
-    form {
-      max-width: 600px;
-      margin: 0 auto;
-    }
-  </style>
+    <link rel="stylesheet" href="assets/styles/main.css">
+
 </head>
 <body>
   <header>
@@ -92,7 +26,7 @@
         <a href="https://bodyosapp.co" class="button">BodyOS Web App</a>
       </div>
       <div>
-        <h1 style="color: #ff4f00;">BODY<span style="color:white;">OS</span></h1>
+        <h1 style="color: var(--color-orange);">BODY<span style="color: var(--color-text-light);">OS</span></h1>
         <p>The Ultimate Bioanalysis Platform</p>
         <small>Private Alpha Access – Invite Code Required</small>
       </div>


### PR DESCRIPTION
## Summary
- move inline `<style>` rules into `assets/styles/main.css`
- define CSS design tokens for colors, typography, and spacing
- reference the new stylesheet from `index.html` and use color tokens for the BodyOS heading

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915e1dd2b0832e801598fec04bddd4